### PR TITLE
Minor fixes to modqueue commands

### DIFF
--- a/discord/commands/modqueue.js
+++ b/discord/commands/modqueue.js
@@ -16,6 +16,12 @@ module.exports.run = (CommandStruct, PermStruct) => {
   CommandStruct.message.channel.send(modqueueRequest);
   const modQueue = CommandStruct.message.guild.channels.cache.get('744768964630020136');
   modQueue.send(modqueueRequest);
+
+  try {
+    CommandStruct.message.delete();
+  } catch(err) {
+    return;
+  }
 }
 
 // This should be a string, it will be used in the detailed help command for a specific command

--- a/discord/commands/mqcomplete.js
+++ b/discord/commands/mqcomplete.js
@@ -31,4 +31,4 @@ module.exports.helpText = `Used to mark a modqueue request as completed`
 // This should be a string. It will be used for general help to list commands by category
 module.exports.Category = `Mod`
 
-module.exports.RequiredPermissions = [perms.levels.Admin]
+module.exports.RequiredPermissions = ['BotManager']

--- a/discord/commands/mqinprogress.js
+++ b/discord/commands/mqinprogress.js
@@ -31,4 +31,4 @@ module.exports.helpText = `Used to mark a modqueue request as in progress`
 // This should be a string. It will be used for general help to list commands by category
 module.exports.Category = `Mod`
 
-module.exports.RequiredPermissions = [perms.levels.Admin]
+module.exports.RequiredPermissions = ['BotManager']

--- a/discord/commands/mqreject.js
+++ b/discord/commands/mqreject.js
@@ -31,4 +31,4 @@ module.exports.helpText = `Used to mark a modqueue request as rejected`
 // This should be a string. It will be used for general help to list commands by category
 module.exports.Category = `Mod`
 
-module.exports.RequiredPermissions = [perms.levels.Admin]
+module.exports.RequiredPermissions = ['BotManager']


### PR DESCRIPTION
- ~modqueue now deletes the original message as it's already contained in the request sent by the bot, as it was with the original modqueue
- Fixed issue where modqueue request-marking commands required administrator to be run, preventing minimods from using them