### PR TITLE
Command/Flag adjustments

### DIFF
--- a/discord/commands/flag.js
+++ b/discord/commands/flag.js
@@ -17,7 +17,7 @@ module.exports.run = async (CommandStruct, PermStruct) => {
     } else if (CommandStruct.args[0].toLowerCase() == "green") {
         flag = "https://i.imgur.com/MNKwjES.jpg"
     } else if (CommandStruct.args[0].toLowerCase() == "blue") {
-        flag = "https://i.imgur.com/IymoMsy.png"
+        flag = "https://i.imgur.com/tmFG3VI.png"
     } else if (CommandStruct.args[0].toLowerCase() == "purple") {
         flag = "https://i.imgur.com/rZFSCIP.jpg"
     } else if (CommandStruct.args[0].toLowerCase() == "oil" || CommandStruct.args[0].toLowerCase() == "mod") {

--- a/discord/commands/mqcomplete.js
+++ b/discord/commands/mqcomplete.js
@@ -5,8 +5,9 @@ const perms = require('../eval_perms');
 // The run function should ALWAYS take CommandStruct and PermStruct
 module.exports.run = (CommandStruct, PermStruct) => {
   if(!CommandStruct.args[0]) return CommandStruct.message.reply("You haven't specified a valid message ID");
-  const modQueue = CommandStruct.message.guild.channels.cache.get('703431121857282108');
+  const modQueue = CommandStruct.message.guild.channels.cache.get('703431121857282108'); //Megaserver #modqueue ID: 703431121857282108
   let usrMsg = CommandStruct.message;
+  CommandStruct.message.delete();
 
   modQueue.messages.fetch(CommandStruct.args[0]).then(message => {
 
@@ -14,14 +15,14 @@ module.exports.run = (CommandStruct, PermStruct) => {
 
     .setColor('18aa08')
     .setTimestamp()
-    .setFooter('Request Has Been Completed: ');
+    .setFooter(`Request Marked Completed By ${usrMsg.author.tag}: `);
 
     message.edit('', {embed: newMQEmbed});
-    usrMsg.reply("Request has been completed! You may now delete the modqueue logging from the \`#modqueue-requests\` channel");
+    usrMsg.channel.send("Request has been completed! You may now delete the modqueue logging from the \`#modqueue-requests\` channel").then(msg => msg.delete({timeout: 6000}));
     //const modQueue = CommandStruct.message.guild.channels.cache.get('815937228680200203');
     //modQueue.edit('', {embed: newMQEmbed});
   }).catch(err => {
-    return usrMsg.reply("I couldn't find any messages in the modqueue channel with that message ID");
+    return usrMsg.channel.send("I couldn't find any messages in the modqueue channel with that message ID").then(msg => msg.delete({timeout: 6000}));
   })
 }
 

--- a/discord/commands/mqinprogress.js
+++ b/discord/commands/mqinprogress.js
@@ -5,8 +5,9 @@ const perms = require('../eval_perms');
 // The run function should ALWAYS take CommandStruct and PermStruct
 module.exports.run = (CommandStruct, PermStruct) => {
   if(!CommandStruct.args[0]) return CommandStruct.message.reply("You haven't specified a valid message ID");
-  const modQueue = CommandStruct.message.guild.channels.cache.get('703431121857282108');
+  const modQueue = CommandStruct.message.guild.channels.cache.get('703431121857282108'); //Megaserver #modqueue ID: 703431121857282108
   let usrMsg = CommandStruct.message;
+  CommandStruct.message.delete();
 
   modQueue.messages.fetch(CommandStruct.args[0]).then(message => {
 
@@ -14,14 +15,14 @@ module.exports.run = (CommandStruct, PermStruct) => {
 
     .setColor('dea305')
     .setTimestamp()
-    .setFooter('Request In Progress: ');
+    .setFooter(`Request Marked In Progress By ${usrMsg.author.tag}: `);
 
     message.edit('', {embed: newMQEmbed});
-    usrMsg.reply("Request has been marked as in progress!");
+    usrMsg.channel.send("Request has been marked as in progress!").then(msg => msg.delete({timeout: 6000}));
     //const modQueue = CommandStruct.message.guild.channels.cache.get('815937228680200203');
     //modQueue.edit('', {embed: newMQEmbed});
   }).catch(err => {
-    return usrMsg.reply("I couldn't find any messages in the modqueue channel with that message ID");
+    return usrMsg.channel.send("I couldn't find any messages in the modqueue channel with that message ID").then(msg => msg.delete({timeout: 6000}));
   })
 }
 

--- a/discord/commands/mqreject.js
+++ b/discord/commands/mqreject.js
@@ -5,8 +5,9 @@ const perms = require('../eval_perms');
 // The run function should ALWAYS take CommandStruct and PermStruct
 module.exports.run = (CommandStruct, PermStruct) => {
   if(!CommandStruct.args[0]) return CommandStruct.message.reply("You haven't specified a valid message ID");
-  const modQueue = CommandStruct.message.guild.channels.cache.get('703431121857282108');
+  const modQueue = CommandStruct.message.guild.channels.cache.get('703431121857282108'); //Megaserver #modqueue ID: 703431121857282108
   let usrMsg = CommandStruct.message;
+  CommandStruct.message.delete();
 
   modQueue.messages.fetch(CommandStruct.args[0]).then(message => {
 
@@ -14,14 +15,14 @@ module.exports.run = (CommandStruct, PermStruct) => {
 
     .setColor('da1313')
     .setTimestamp()
-    .setFooter('Request Has Been Rejected: ');
+    .setFooter(`Request Rejected By ${usrMsg.author.tag}: `);
 
     message.edit('', {embed: newMQEmbed});
-    usrMsg.reply("Request has been rejected! You may now delete the modqueue logging from the \`#modqueue-requests\` channel");
+    usrMsg.channel.send("Request has been rejected! You may now delete the modqueue logging from the \`#modqueue-requests\` channel").then(msg => msg.delete({timeout: 6000}));
     //const modQueue = CommandStruct.message.guild.channels.cache.get('815937228680200203');
     //modQueue.edit('', {embed: newMQEmbed});
   }).catch(err => {
-    return usrMsg.reply("I couldn't find any messages in the modqueue channel with that message ID");
+    return usrMsg.channel.send("I couldn't find any messages in the modqueue channel with that message ID").then(msg => msg.delete({timeout: 6000}));
   })
 }
 

--- a/discord/flairwarsInfo.js
+++ b/discord/flairwarsInfo.js
@@ -37,7 +37,7 @@ const info = {
 
       "green": { name: "Green", colourHex: "#3ACE04", iconUrl: "https://i.imgur.com/MNKwjES.jpg", squareIconUrl: "https://i.imgur.com/snuQd1y.jpg", "serverInvite": "https://discord.gg/4HH6D64", subreddit: "TheGreenArmy"},
 
-      "blue": { name: "Blue", colourHex: "#213AEF", iconUrl: "https://i.imgur.com/IymoMsy.png", squareIconUrl: "https://i.imgur.com/JTun9uC.jpg", "serverInvite": "https://discord.gg/W7rnJJQ", subreddit: "AzureEmpire"},
+      "blue": { name: "Blue", colourHex: "#213AEF", iconUrl: "https://i.imgur.com/tmFG3VI.png", squareIconUrl: "https://i.imgur.com/EN1y1I3.png", "serverInvite": "https://discord.gg/W7rnJJQ", subreddit: "AzureEmpire"},
 
       "purple": { name: "Purple", colourHex: "#AF0ECC", iconUrl: "https://i.imgur.com/rZFSCIP.jpg", squareIconUrl: "https://i.imgur.com/a0yMVjz.jpg", "serverInvite": "https://discord.gg/MnsDKcc", subreddit: "PurpleImperium"},
 


### PR DESCRIPTION
- Modqueue request-marking commands now deletes the message that marked the request as well as the system message after a few seconds, in order to minimise extra clutter in #modqueue-requests
- Modqueue request-marking commands now also show who marked a request when the request message is edited by the bot
- Updated the blue flag images/icons in ~flag, ~sub and flairInfo.js